### PR TITLE
Adding mypy linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # History
 
 ## Unreleased
+### Changed
+- The mixed-type list of backends `dframeio.backends` was removed in favor of two lists `dframeio.read_backends` `dframeio.write_backends`. This is better suitable for the use case of backend discovery.
+
+### Fixed
+- PostgresBackend.read_to_dict() had an indentation error which made the function return a variable which was already out-of-scope.
 
 ## 0.3.0 (2021-11-08)
 ### Added

--- a/dframeio/__init__.py
+++ b/dframeio/__init__.py
@@ -1,14 +1,19 @@
 """Top-level package for dataframe-io."""
+import typing
+
+from .abstract import AbstractDataFrameReader, AbstractDataFrameWriter
 
 __version__ = "0.2.0"
 
 # Add Backends one by one if dependencies are available
-backends = []
+read_backends: typing.List[typing.Type[AbstractDataFrameReader]] = []
+write_backends: typing.List[typing.Type[AbstractDataFrameWriter]] = []
 
 try:
     from dframeio.parquet import ParquetBackend
 
-    backends.append(ParquetBackend)
+    read_backends.append(ParquetBackend)
+    write_backends.append(ParquetBackend)
 except ModuleNotFoundError as e:
     if e.name == "pyarrow":
         pass
@@ -18,7 +23,8 @@ except ModuleNotFoundError as e:
 try:
     from dframeio.postgres import PostgresBackend
 
-    backends.append(PostgresBackend)
+    read_backends.append(PostgresBackend)
+    write_backends.append(PostgresBackend)
 except ModuleNotFoundError as e:
     if e.name == "psycopg":
         pass

--- a/dframeio/abstract.py
+++ b/dframeio/abstract.py
@@ -2,10 +2,7 @@
 from abc import abstractmethod
 from typing import Dict, List, Union
 
-try:
-    import pandas as pd
-except ImportError:
-    pd = None  # type: ignore
+import pandas as pd
 
 
 class AbstractDataFrameReader:

--- a/dframeio/abstract.py
+++ b/dframeio/abstract.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Union
 try:
     import pandas as pd
 except ImportError:
-    pd = None
+    pd = None  # type: ignore
 
 
 class AbstractDataFrameReader:

--- a/dframeio/filter.py
+++ b/dframeio/filter.py
@@ -205,7 +205,7 @@ class _PyarrowDNFTransformer(lark.Transformer):
 
     @dataclass
     class Condition:
-        key: str
+        key: Any
         operator: str
         value: Union[str, int, float]
 

--- a/dframeio/parquet.py
+++ b/dframeio/parquet.py
@@ -5,11 +5,11 @@ import random
 import re
 import shutil
 from pathlib import Path
-from typing import Dict, Iterable, List, Union
+from typing import Any, Dict, Iterable, List, Union
 
 import pandas as pd
-import pyarrow as pa
-import pyarrow.parquet as pq
+import pyarrow as pa  # type: ignore  # Type hints are missing in pyarrow
+import pyarrow.parquet as pq  # type: ignore  # Type hints are missing in pyarrow
 
 import dframeio.filter
 
@@ -252,7 +252,7 @@ class ParquetBackend(AbstractDataFrameReader, AbstractDataFrameWriter):
                 )
 
     @staticmethod
-    def _remove_matching_keys(d: collections.abc.Mapping, regex: str):
+    def _remove_matching_keys(d: Dict[str, Any], regex: str):
         """Remove all keys matching regex from the dictionary d"""
         compiled_regex = re.compile(regex)
         keys_to_delete = [k for k in d.keys() if compiled_regex.match(k)]
@@ -333,7 +333,7 @@ class ParquetBackend(AbstractDataFrameReader, AbstractDataFrameWriter):
         """
         kwargs = dict(columns=columns, use_threads=True, use_pandas_metadata=use_pandas_metadata)
         if row_filter:
-            kwargs["filters"] = dframeio.filter.to_pyarrow_dnf(row_filter)
+            kwargs["filters"] = dframeio.filter.to_pyarrow_dnf(row_filter)  # type: ignore
         df = pq.read_table(str(full_path), **kwargs)
         if limit >= 0:
             df = df.slice(0, min(df.num_rows, limit))

--- a/dframeio/postgres.py
+++ b/dframeio/postgres.py
@@ -30,7 +30,7 @@ class PostgresBackend(AbstractDataFrameReader, AbstractDataFrameWriter):
     _connection: psycopg.Connection
     _batch_size: int = 1000
 
-    def __init__(self, conninfo: str = None, *, autocommit=True):
+    def __init__(self, conninfo: str, *, autocommit=True):
         super().__init__()
         self._connection = psycopg.connect(conninfo=conninfo, autocommit=autocommit)
 
@@ -91,6 +91,11 @@ class PostgresBackend(AbstractDataFrameReader, AbstractDataFrameWriter):
         Returns:
             A dictionary with column names as key and a list with column values as values
 
+        Raises:
+            EOFError: If PostgreSQL does not return a valid result of the query. Note that
+                this doesn't apply for an empty result set. In this case the values in the
+                dictionary returned are simply empty lists.
+
         The logic of the filtering arguments is as documented for
         [`read_to_pandas()`](dframeio.abstract.AbstractDataFrameReader.read_to_pandas).
         """
@@ -98,6 +103,8 @@ class PostgresBackend(AbstractDataFrameReader, AbstractDataFrameWriter):
 
         with self._connection.cursor() as cursor:
             cursor.execute(query)
+            if cursor.pgresult is None or cursor.description is None:
+                raise EOFError("No result from postgres due to an unknown issue")
             # Preallocate dataframe as list of lists
             table = [[None] * cursor.rowcount for _ in range(cursor.pgresult.nfields)]
             # Fetch the data
@@ -119,7 +126,7 @@ class PostgresBackend(AbstractDataFrameReader, AbstractDataFrameWriter):
         limit: int = -1,
         sample: int = -1,
         drop_duplicates: bool = False,
-    ) -> psql.SQL:
+    ) -> psql.Composed:
         """Compose a full SQL query from the information given in the arguments.
 
         Args:
@@ -167,7 +174,7 @@ class PostgresBackend(AbstractDataFrameReader, AbstractDataFrameWriter):
         return psql.SQL("")
 
     @staticmethod
-    def _make_columns_clause(columns: List[str]) -> psql.SQL:
+    def _make_columns_clause(columns: List[str] = None) -> psql.Composable:
         """Create the list of columns for a select statement in psql syntax"""
         if isinstance(columns, str):
             raise TypeError(f"'columns' must be a list of column names. Got '{columns}'")

--- a/poetry.lock
+++ b/poetry.lock
@@ -491,6 +491,24 @@ dev = ["bump2version (==1.0.1)", "flake8 (==3.9.2)", "flake8-implicit-str-concat
 test = ["pytest (==6.2.4)", "pytest-cov (==2.12.1)"]
 
 [[package]]
+name = "mypy"
+version = "0.910"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3,<0.5.0"
+toml = "*"
+typed-ast = {version = ">=1.4.0,<1.5.0", markers = "python_version < \"3.8\""}
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<1.5.0)"]
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -1036,11 +1054,11 @@ tqdm = ">=4.14"
 
 [[package]]
 name = "typed-ast"
-version = "1.5.0"
+version = "1.4.3"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
@@ -1157,7 +1175,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<4.0"
-content-hash = "309adf9927e6f10135ff56ba7bf7a9a820a7c67b5bc51af59e870c187cfb5af7"
+content-hash = "f3a1ecb874086bacbfbd468c759eeb347e8cfb83cf0d9991956e24ba7b3b6377"
 
 [metadata.files]
 astroid = [
@@ -1497,6 +1515,31 @@ mkdocs-include-markdown-plugin = [
     {file = "mkdocs_include_markdown_plugin-3.2.3-py3-none-any.whl", hash = "sha256:5a8b0c60d8981225c012b8f657b6557910997e46dacae4aff039b181487236cf"},
     {file = "mkdocs_include_markdown_plugin-3.2.3.tar.gz", hash = "sha256:64dd8c408a1b5b7422d4a5a826c434e5372af2fb7bd244dd5c87e09ff8f13302"},
 ]
+mypy = [
+    {file = "mypy-0.910-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9"},
+    {file = "mypy-0.910-cp35-cp35m-win_amd64.whl", hash = "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e"},
+    {file = "mypy-0.910-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212"},
+    {file = "mypy-0.910-cp36-cp36m-win_amd64.whl", hash = "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885"},
+    {file = "mypy-0.910-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703"},
+    {file = "mypy-0.910-cp37-cp37m-win_amd64.whl", hash = "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a"},
+    {file = "mypy-0.910-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504"},
+    {file = "mypy-0.910-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9"},
+    {file = "mypy-0.910-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072"},
+    {file = "mypy-0.910-cp38-cp38-win_amd64.whl", hash = "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811"},
+    {file = "mypy-0.910-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e"},
+    {file = "mypy-0.910-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b"},
+    {file = "mypy-0.910-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2"},
+    {file = "mypy-0.910-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97"},
+    {file = "mypy-0.910-cp39-cp39-win_amd64.whl", hash = "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8"},
+    {file = "mypy-0.910-py3-none-any.whl", hash = "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"},
+    {file = "mypy-0.910.tar.gz", hash = "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150"},
+]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
@@ -1833,25 +1876,36 @@ twine = [
     {file = "twine-3.6.0.tar.gz", hash = "sha256:4caad5ef4722e127b3749052fcbffaaf71719b19d4fd4973b29c469957adeba2"},
 ]
 typed-ast = [
-    {file = "typed_ast-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7b310a207ee9fde3f46ba327989e6cba4195bc0c8c70a158456e7b10233e6bed"},
-    {file = "typed_ast-1.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:52ca2b2b524d770bed7a393371a38e91943f9160a190141e0df911586066ecda"},
-    {file = "typed_ast-1.5.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:14fed8820114a389a2b7e91624db5f85f3f6682fda09fe0268a59aabd28fe5f5"},
-    {file = "typed_ast-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:65c81abbabda7d760df7304d843cc9dbe7ef5d485504ca59a46ae2d1731d2428"},
-    {file = "typed_ast-1.5.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:37ba2ab65a0028b1a4f2b61a8fe77f12d242731977d274a03d68ebb751271508"},
-    {file = "typed_ast-1.5.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:49af5b8f6f03ed1eb89ee06c1d7c2e7c8e743d720c3746a5857609a1abc94c94"},
-    {file = "typed_ast-1.5.0-cp36-cp36m-win_amd64.whl", hash = "sha256:e4374a76e61399a173137e7984a1d7e356038cf844f24fd8aea46c8029a2f712"},
-    {file = "typed_ast-1.5.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ea517c2bb11c5e4ba7a83a91482a2837041181d57d3ed0749a6c382a2b6b7086"},
-    {file = "typed_ast-1.5.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:51040bf45aacefa44fa67fb9ebcd1f2bec73182b99a532c2394eea7dabd18e24"},
-    {file = "typed_ast-1.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:806e0c7346b9b4af8c62d9a29053f484599921a4448c37fbbcbbf15c25138570"},
-    {file = "typed_ast-1.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a67fd5914603e2165e075f1b12f5a8356bfb9557e8bfb74511108cfbab0f51ed"},
-    {file = "typed_ast-1.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:224afecb8b39739f5c9562794a7c98325cb9d972712e1a98b6989a4720219541"},
-    {file = "typed_ast-1.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:155b74b078be842d2eb630dd30a280025eca0a5383c7d45853c27afee65f278f"},
-    {file = "typed_ast-1.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:361b9e5d27bd8e3ccb6ea6ad6c4f3c0be322a1a0f8177db6d56264fa0ae40410"},
-    {file = "typed_ast-1.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:618912cbc7e17b4aeba86ffe071698c6e2d292acbd6d1d5ec1ee724b8c4ae450"},
-    {file = "typed_ast-1.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7e6731044f748340ef68dcadb5172a4b1f40847a2983fe3983b2a66445fbc8e6"},
-    {file = "typed_ast-1.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e8a9b9c87801cecaad3b4c2b8876387115d1a14caa602c1618cedbb0cb2a14e6"},
-    {file = "typed_ast-1.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:ec184dfb5d3d11e82841dbb973e7092b75f306b625fad7b2e665b64c5d60ab3f"},
-    {file = "typed_ast-1.5.0.tar.gz", hash = "sha256:ff4ad88271aa7a55f19b6a161ed44e088c393846d954729549e3cde8257747bb"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805"},
+    {file = "typed_ast-1.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win32.whl", hash = "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40"},
+    {file = "typed_ast-1.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
+    {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ test = [
     "flake8",
     "flake8-docstrings",
     "pytest-cov",
-    "yamllint"
+    "yamllint",
+    "mypy"
 ]
 
 dev = ["tox", "pre-commit", "virtualenv", "pip", "twine", "toml"]
@@ -80,6 +81,7 @@ pylint-junit = "*"
 #Jinja2 = "^3.0.1"  # This is only for pyparsing[diagrams]
 pydot = "^1.4.2"
 psycopg = "^3.0.1"
+mypy = "^0.910"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_abstract_interfaces.py
+++ b/tests/test_abstract_interfaces.py
@@ -14,7 +14,7 @@ def method_names(cls: typing.Type) -> typing.List[str]:
 
 
 @pytest.mark.parametrize("function", method_names(abstract.AbstractDataFrameReader))
-@pytest.mark.parametrize("backend", dframeio.backends)
+@pytest.mark.parametrize("backend", dframeio.read_backends)
 def test_abstract_reader__methods_implemented(backend: typing.Type, function: str):
     """Checks if all functions of AbstractDataFrameReader are implemented"""
     method = getattr(backend, function)
@@ -24,7 +24,7 @@ def test_abstract_reader__methods_implemented(backend: typing.Type, function: st
 
 
 @pytest.mark.parametrize("function", method_names(abstract.AbstractDataFrameReader))
-@pytest.mark.parametrize("backend", dframeio.backends)
+@pytest.mark.parametrize("backend", dframeio.read_backends)
 def test_abstract_reader_method_signatures(backend: typing.Type, function: str):
     """Checks function signatures of all AbstractDataFrameReader implementations
 
@@ -33,5 +33,29 @@ def test_abstract_reader_method_signatures(backend: typing.Type, function: str):
     type hints.
     """
     abstract_signature = inspect.getfullargspec(getattr(abstract.AbstractDataFrameReader, function))
+    concrete_signature = inspect.getfullargspec(getattr(backend, function))
+    assert concrete_signature == abstract_signature
+
+
+@pytest.mark.parametrize("function", method_names(abstract.AbstractDataFrameWriter))
+@pytest.mark.parametrize("backend", dframeio.write_backends)
+def test_abstract_writer__methods_implemented(backend: typing.Type, function: str):
+    """Checks if all functions of AbstractDataFrameWriter are implemented"""
+    method = getattr(backend, function)
+    assert not hasattr(
+        method, "__isabstractmethod__"
+    ), f"{function}() not implemented for {backend}"
+
+
+@pytest.mark.parametrize("function", method_names(abstract.AbstractDataFrameWriter))
+@pytest.mark.parametrize("backend", dframeio.write_backends)
+def test_abstract_writer_method_signatures(backend: typing.Type, function: str):
+    """Checks function signatures of all AbstractDataFrameWriter implementations
+
+    This checks if the signature of all implemented methods are the same as in the
+    base class. Arguments have to be the same, including names, default values and
+    type hints.
+    """
+    abstract_signature = inspect.getfullargspec(getattr(abstract.AbstractDataFrameWriter, function))
     concrete_signature = inspect.getfullargspec(getattr(backend, function))
     assert concrete_signature == abstract_signature

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,29 @@
+"""Tests for the handling of missing optional dependencies"""
+import importlib
+import sys
+
+
+def test_missing_psycopg(monkeypatch):
+    monkeypatch.setitem(sys.modules, "psycopg", None)
+    import dframeio
+
+    importlib.reload(dframeio)
+    import dframeio.filter
+
+    importlib.reload(dframeio.filter)
+    import dframeio.abstract
+
+    importlib.reload(dframeio.abstract)
+
+
+def test_missing_pyarrow(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pyarrow", None)
+    import dframeio
+
+    importlib.reload(dframeio)
+    import dframeio.filter
+
+    importlib.reload(dframeio.filter)
+    import dframeio.abstract
+
+    importlib.reload(dframeio.abstract)

--- a/tox.ini
+++ b/tox.ini
@@ -13,16 +13,18 @@ allowlist_externals =
     isort
     black
     flake8
+    mypy
     pylint
     yamllint
 extras =
     test
     dev
 commands =
-    isort dframeio
-    black dframeio tests
-    flake8 dframeio tests
-    pylint --output-format=colorized -r y --fail-under 9.0 dframeio tests
+    isort dframeio tests integration_tests
+    black dframeio tests integration_tests
+    flake8 dframeio tests integration_tests
+    pylint --output-format=colorized -r y --fail-under 9.0 dframeio
+    mypy dframeio
     yamllint -d '\{extends: relaxed, ignore: local, rules: \{line-length: disable\}\}' .
 
 [testenv:build]


### PR DESCRIPTION
The extensive type hints were so far only used in the IDE. Now mypy is executed by tox on PR checks.